### PR TITLE
fix putting app opening twice

### DIFF
--- a/src/connections/PuttingConnection.cs
+++ b/src/connections/PuttingConnection.cs
@@ -138,6 +138,7 @@ namespace gspro_r10
       {
         if (e.Club == OpenConnect.Club.PT)
         {
+          if (!PuttingEnabled)
           StartPutting();
         }
         else


### PR DESCRIPTION
If gspro is sending twice the information of PT being selected and the putting process is not fully started yet it happens that the putting window will be started twice. Mostly this happens on initial launch of the putting app as this takes a bit longer. This changed worked for me in a local copy of your connector to fix the issue. Please check if you can release a fix based on this otherwise I can also release it on my github. Related issue is also reported here: https://github.com/mholow/gsp-r10-adapter/issues/30