### PR TITLE
support for OSG, update to use dotnet 9.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# gsp-r10-adapter
+# OSG-R10-Adapter
 
-Utility to bridge R10 launch monitor to GSPro. Supports the following
+Utility to bridge R10 launch monitor to GSPro and OpenShotGolf (OSG). Supports the following
   - An "E6 Connect" compatible server for use with the Launch Monitor's E6 integration
   - Direct bluetooth connection to R10
   - Webcam putting integration with https://github.com/alleexx/cam-putting-py
@@ -41,5 +41,7 @@ In order to use the putting integration you must
 
 ### From Source
 
-- Install a dotnet 7 sdk if you don't have one already
+- Install a dotnet 9 sdk if you don't have one already
 - `dotnet run` from project directory
+- You can force the simulator target with `dotnet run -- --sim gspro` or `dotnet run -- --sim osg` (the `--` separates app args from dotnet)
+- Without the flag, the simulator is inferred from `openConnect.port` in `settings.json` (`49152` => OpenShotGolf, `921` => GSPro)

--- a/gspro-r10.csproj
+++ b/gspro-r10.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0-windows10.0.19041</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.19041</TargetFramework>
     <RootNamespace>gspro_r10</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/settings.json
+++ b/settings.json
@@ -1,7 +1,7 @@
 {
   "openConnect": {
     "ip": "127.0.0.1",
-    "port": 921
+    "port": 49152
   },
   "r10E6Server": {
     "enabled": true,

--- a/src/ConnectionManager.cs
+++ b/src/ConnectionManager.cs
@@ -2,13 +2,14 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using gspro_r10.OpenConnect;
 using Microsoft.Extensions.Configuration;
+using System.Collections.Generic;
 
 namespace gspro_r10
 {
   public class ConnectionManager: IDisposable
   {
     private R10ConnectionServer? R10Server;
-    private OpenConnectClient OpenConnectClient;
+    private List<IOpenConnectClient> OpenConnectClients = new List<IOpenConnectClient>();
     private BluetoothConnection? BluetoothConnection { get; }
     internal HttpPuttingServer? PuttingConnection { get; }
     public event ClubChangedEventHandler? ClubChanged;
@@ -25,11 +26,18 @@ namespace gspro_r10
 
     private int shotNumber = 0;
     private bool disposedValue;
+    private readonly SimulatorType? simulatorOverride;
 
-    public ConnectionManager(IConfigurationRoot configuration)
+    public ConnectionManager(IConfigurationRoot configuration, SimulatorType? simulatorOverride = null)
     {
-      OpenConnectClient = new OpenConnectClient(this, configuration.GetSection("openConnect"));
-      OpenConnectClient.ConnectAsync();
+      this.simulatorOverride = simulatorOverride;
+      AddOpenConnectClient(configuration.GetSection("openConnect"));
+
+      IConfigurationSection secondaryOpenConnect = configuration.GetSection("secondaryOpenConnect");
+      if (bool.Parse(secondaryOpenConnect["enabled"] ?? "false"))
+      {
+        AddOpenConnectClient(secondaryOpenConnect);
+      }
 
       if (bool.Parse(configuration.GetSection("r10E6Server")["enabled"] ?? "false"))
       {
@@ -47,6 +55,37 @@ namespace gspro_r10
       }
     }
 
+    private void AddOpenConnectClient(IConfigurationSection configurationSection)
+    {
+      SimulatorType simulator = DetermineSimulator(configurationSection);
+      IOpenConnectClient client = simulator switch
+      {
+        SimulatorType.OpenShotGolf => new OpenShotGolfClient(this, configurationSection),
+        _ => new OpenConnectClient(this, configurationSection)
+      };
+
+      OpenConnectClients.Add(client);
+      client.ConnectAsync();
+      BaseLogger.LogMessage($"Configured {simulator} connection to {(configurationSection["ip"] ?? "127.0.0.1")}:{configurationSection["port"]}", "Main");
+    }
+
+    private SimulatorType DetermineSimulator(IConfigurationSection configurationSection)
+    {
+      if (simulatorOverride.HasValue)
+        return simulatorOverride.Value;
+
+      if (int.TryParse(configurationSection["port"], out int port))
+      {
+        if (port == 49152)
+          return SimulatorType.OpenShotGolf;
+        if (port == 921)
+          return SimulatorType.GSPro;
+      }
+
+      // Default to GSPro if unrecognized
+      return SimulatorType.GSPro;
+    }
+
     internal void SendShot(OpenConnect.BallData? ballData, OpenConnect.ClubData? clubData)
     {
       string openConnectMessage = JsonSerializer.Serialize(OpenConnectApiMessage.CreateShotData(
@@ -55,7 +94,7 @@ namespace gspro_r10
         clubData
       ), serializerSettings);
 
-      OpenConnectClient.SendAsync(openConnectMessage);
+      OpenConnectClients.ForEach(client => client.SendAsync(openConnectMessage));
     }
 
     public void ClubUpdate(Club club)
@@ -71,7 +110,7 @@ namespace gspro_r10
 
     internal void SendLaunchMonitorReadyUpdate(bool deviceReady)
     {
-      OpenConnectClient.SetDeviceReady(deviceReady);
+      OpenConnectClients.ForEach(client => client.SetDeviceReady(deviceReady));
     }
 
     protected virtual void Dispose(bool disposing)
@@ -83,8 +122,10 @@ namespace gspro_r10
           R10Server?.Dispose();
           PuttingConnection?.Dispose();
           BluetoothConnection?.Dispose();
-          OpenConnectClient?.DisconnectAndStop();
-          OpenConnectClient?.Dispose();
+          OpenConnectClients.ForEach(client => {
+            client?.DisconnectAndStop();
+            client?.Dispose();
+          });
         }
         disposedValue = true;
       }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -4,9 +4,10 @@ namespace gspro_r10
 {
   class Program
   {
-    public static void Main()
+    public static void Main(string[] args)
     {
-      
+      SimulatorType? simulatorOverride = ParseSimulatorArgument(args);
+
       IConfigurationBuilder builder = new ConfigurationBuilder()
         .SetBasePath(Directory.GetCurrentDirectory());
 
@@ -20,14 +21,60 @@ namespace gspro_r10
       }
 
       IConfigurationRoot configuration = builder.Build();
-      
+
       Console.Title = "GSP-R10 Connect";
       BaseLogger.LogMessage("GSP - R10 Bridge starting. Press enter key to close", "Main");
-      ConnectionManager manager = new ConnectionManager(configuration);
+      if (simulatorOverride.HasValue)
+      {
+        BaseLogger.LogMessage($"Simulator override set to {simulatorOverride.Value}", "Main");
+      }
+      ConnectionManager manager = new ConnectionManager(configuration, simulatorOverride);
       Console.ReadLine();
       BaseLogger.LogMessage("Shutting down...", "Main");
       manager.Dispose();
       BaseLogger.LogMessage("Exiting...", "Main");
+    }
+
+    private static SimulatorType? ParseSimulatorArgument(string[] args)
+    {
+      for (int i = 0; i < args.Length; i++)
+      {
+        string current = args[i];
+
+        if (current.Equals("--sim", StringComparison.OrdinalIgnoreCase) ||
+            current.Equals("-s", StringComparison.OrdinalIgnoreCase))
+        {
+          if (i + 1 < args.Length && TryParseSimulator(args[i + 1], out var simulator))
+            return simulator;
+        }
+        else if (current.StartsWith("--sim=", StringComparison.OrdinalIgnoreCase))
+        {
+          string value = current.Substring("--sim=".Length);
+          if (TryParseSimulator(value, out var simulator))
+            return simulator;
+        }
+      }
+
+      return null;
+    }
+
+    private static bool TryParseSimulator(string value, out SimulatorType simulator)
+    {
+      switch (value.ToLowerInvariant())
+      {
+        case "gspro":
+        case "gsp":
+          simulator = SimulatorType.GSPro;
+          return true;
+        case "osg":
+        case "openshotgolf":
+          simulator = SimulatorType.OpenShotGolf;
+          return true;
+        default:
+          simulator = SimulatorType.GSPro;
+          BaseLogger.LogMessage($"Unknown simulator '{value}'. Supported values: gspro, osg.", "Main", LogMessageType.Error);
+          return false;
+      }
     }
   }
 }

--- a/src/SimulatorType.cs
+++ b/src/SimulatorType.cs
@@ -1,0 +1,8 @@
+namespace gspro_r10
+{
+  public enum SimulatorType
+  {
+    GSPro,
+    OpenShotGolf
+  }
+}

--- a/src/api/OpenConnectApi.cs
+++ b/src/api/OpenConnectApi.cs
@@ -4,7 +4,7 @@ namespace gspro_r10.OpenConnect
 {
   public class OpenConnectApiMessage
   {
-    public string DeviceID { get { return "GSPRO-R10"; } }
+    public string DeviceID { get { return "Garmin-R10"; } }
     public string Units { get { return "Yards"; } }
     public int ShotNumber { get; set; }
     public string APIVersion { get { return "1"; } }

--- a/src/connections/IOpenConnectClient.cs
+++ b/src/connections/IOpenConnectClient.cs
@@ -1,0 +1,10 @@
+namespace gspro_r10
+{
+  public interface IOpenConnectClient : IDisposable
+  {
+    bool ConnectAsync();
+    void DisconnectAndStop();
+    void SetDeviceReady(bool deviceReady);
+    bool SendAsync(string message);
+  }
+}

--- a/src/connections/OpenConnectConnection.cs
+++ b/src/connections/OpenConnectConnection.cs
@@ -7,17 +7,19 @@ using TcpClient = NetCoreServer.TcpClient;
 
 namespace gspro_r10
 {
-  class OpenConnectClient : TcpClient
+  class OpenConnectClient : TcpClient, IOpenConnectClient
   {
     public Timer? PingTimer { get; private set; }
     public bool InitiallyConnected { get; private set; }
-    public ConnectionManager ConnectionManager { get; set; }
+    public ConnectionManager ConnectionManager { get; }
+    private SimulatorLogger Logger { get; }
     private bool _stop;
 
-    public OpenConnectClient(ConnectionManager connectionManager, IConfigurationSection configuration)
+    public OpenConnectClient(ConnectionManager connectionManager, IConfigurationSection configuration, SimulatorLogger? logger = null)
       : base(configuration["ip"] ?? "127.0.0.1", int.Parse(configuration["port"] ?? "921"))
     {
       ConnectionManager = connectionManager;
+      Logger = logger ?? new SimulatorLogger("GSPro", ConsoleColor.Green);
     }
 
     public void DisconnectAndStop()
@@ -31,36 +33,36 @@ namespace gspro_r10
     protected override void OnConnected()
     {
       InitiallyConnected = true;
-      OpenConnectLogger.LogGSPInfo($"TCP client connected a new session with Id {Id}");
+      Logger.Info($"TCP client connected a new session with Id {Id}");
       PingTimer = new Timer(SendPing, null, 0, 0);
     }
 
     private void SendPing(object? state)
     {
-      SendAsync(JsonSerializer.Serialize(OpenConnect.OpenConnectApiMessage.CreateHeartbeat()));
+      SendAsync(JsonSerializer.Serialize(OpenConnectApiMessage.CreateHeartbeat()));
     }
 
     public void SetDeviceReady(bool deviceReady)
     {
-      SendAsync(JsonSerializer.Serialize(OpenConnect.OpenConnectApiMessage.CreateHeartbeat(deviceReady)));
+      SendAsync(JsonSerializer.Serialize(OpenConnectApiMessage.CreateHeartbeat(deviceReady)));
     }
 
     public override bool ConnectAsync()
     {
-      OpenConnectLogger.LogGSPInfo($"Connecting to OpenConnect api ({Address}:{Port})...");
+      Logger.Info($"Connecting to OpenConnect api ({Address}:{Port})...");
       return base.ConnectAsync();
     }
 
     public override bool SendAsync(string message)
     {
-      OpenConnectLogger.LogGSPOutgoing(message);
+      Logger.Outgoing(message);
       return base.SendAsync(message);
     }
 
     protected override void OnDisconnected()
     {
       if (InitiallyConnected)
-        OpenConnectLogger.LogGSPError($"TCP client disconnected a session with Id {Id}");
+        Logger.Error($"TCP client disconnected a session with Id {Id}");
 
       Thread.Sleep(5000);
       if (!_stop)
@@ -70,7 +72,7 @@ namespace gspro_r10
     protected override void OnReceived(byte[] buffer, long offset, long size)
     {
       string received = Encoding.UTF8.GetString(buffer, (int)offset, (int)size);
-      OpenConnectLogger.LogGSPIncoming(received);
+      Logger.Incoming(received);
 
       // Sometimes multiple responses received in one buffer. Convert to list format to handle
       // ie "{one}{two}" => "[{one},{two}]"
@@ -85,7 +87,7 @@ namespace gspro_r10
       }
       catch
       {
-        OpenConnectLogger.LogGSPError("Error parsing response");
+        Logger.Error("Error parsing response");
       }
     }
 
@@ -100,17 +102,7 @@ namespace gspro_r10
     protected override void OnError(SocketError error)
     {
       if (error != SocketError.TimedOut)
-        OpenConnectLogger.LogGSPError($"TCP client caught an error with code {error}");
+        Logger.Error($"TCP client caught an error with code {error}");
     }
-  }
-
-  public static class OpenConnectLogger
-  {
-    public static void LogGSPInfo(string message) => LogGSPMessage(message, LogMessageType.Informational);
-    public static void LogGSPError(string message) => LogGSPMessage(message, LogMessageType.Error);
-    public static void LogGSPOutgoing(string message) => LogGSPMessage(message, LogMessageType.Outgoing);
-    public static void LogGSPIncoming(string message) => LogGSPMessage(message, LogMessageType.Incoming);
-    public static void LogGSPMessage(string message, LogMessageType type) => BaseLogger.LogMessage(message, "GSPro", type, ConsoleColor.Green);
-
   }
 }

--- a/src/connections/OpenShotGolfConnection.cs
+++ b/src/connections/OpenShotGolfConnection.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.Configuration;
+
+namespace gspro_r10
+{
+  class OpenShotGolfClient : OpenConnectClient
+  {
+    public OpenShotGolfClient(ConnectionManager connectionManager, IConfigurationSection configuration)
+      : base(connectionManager, configuration, new SimulatorLogger("OSG", ConsoleColor.Green))
+    {
+    }
+  }
+}

--- a/src/connections/SimulatorLogger.cs
+++ b/src/connections/SimulatorLogger.cs
@@ -1,0 +1,24 @@
+namespace gspro_r10
+{
+  public class SimulatorLogger
+  {
+    private readonly string component;
+    private readonly ConsoleColor color;
+
+    public SimulatorLogger(string component, ConsoleColor color)
+    {
+      this.component = component;
+      this.color = color;
+    }
+
+    public void Info(string message) => Log(message, LogMessageType.Informational);
+    public void Error(string message) => Log(message, LogMessageType.Error);
+    public void Outgoing(string message) => Log(message, LogMessageType.Outgoing);
+    public void Incoming(string message) => Log(message, LogMessageType.Incoming);
+
+    private void Log(string message, LogMessageType type)
+    {
+      BaseLogger.LogMessage(message, component, type, color);
+    }
+  }
+}


### PR DESCRIPTION
- Update to use Dotnet 9
- Update to use Open Shot Golf (OSG) https://github.com/jhauck2/OpenShotGolf
- Uses settings port number to decide which Sim to connect to (OR)... 
- Uses flag `dotnet run --sim osg` or `dotnet run --sim gspro` to decide which sim to connect to. 

<img width="2705" height="1178" alt="image" src="https://github.com/user-attachments/assets/d457103f-34b8-4f8b-bbf1-02d1dd6efc9d" />
